### PR TITLE
fix: `store` Schema

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -92,6 +92,7 @@ variable "default_schema_config" {
     from         = string
     object_store = string
     schema       = string
+    store        = string
     index = object({
       prefix = string
       period = string
@@ -117,6 +118,7 @@ variable "additional_schema_config" {
     from         = string
     object_store = string
     schema       = string
+    store        = string
     index = object({
       prefix = string
       period = string


### PR DESCRIPTION
## what
- Add 'store' variable to default and additional schema config

## why
- This was missing from the schema and is required. It's already included with the default value.

## references
```bash
level=error ts=2025-09-29T15:29:30.087250456Z caller=main.go:70 msg="validating config" err="MULTIPLE CONFIG ERRORS FOUND, PLEASE READ CAREFULLY\nunrecognized `store` (index) type ``, choose one of: boltdb-shipper, tsdb\nCONFIG ERROR: `tsdb` index type is required to store Structured Metadata and use native OTLP ingestion, your index type is `` (defined in the `store` parameter of the schema_config). Set `allow_structured_metadata: false` in the `limits_config` section or set the command line argument `-validation.allow-structured-metadata=false` and restart Loki. Then proceed to update the schema to use index type `tsdb` before re-enabling this config, search for 'Storage Schema' in the docs for the schema update procedure"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new “store” property to schema configuration entries, available in both default and additional schema settings. This enables specifying a store value per schema for greater configuration flexibility. Defaults are populated where applicable.
- Chores
  - Updated configuration defaults to include the new “store” field.

Note: If you maintain custom schema configurations, ensure each entry includes the new “store” property to remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->