### PR TITLE
fix: handle empty string in kube_exec_auth_role_arn

### DIFF
--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -101,7 +101,7 @@ locals {
     "--profile", var.kube_exec_auth_aws_profile
   ] : []
 
-  kube_exec_auth_role_arn = coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+  kube_exec_auth_role_arn = var.kube_exec_auth_role_arn != "" ? var.kube_exec_auth_role_arn : try(module.iam_roles.terraform_role_arn, "")
   exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
     "--role-arn", local.kube_exec_auth_role_arn
   ] : []


### PR DESCRIPTION
## What
Fix handling of empty string for `kube_exec_auth_role_arn` variable.

## Why
`coalesce()` only skips null values, not empty strings. When `kube_exec_auth_role_arn` is set to an empty string and `kube_exec_auth_role_arn_enabled` is false, the evaluation still fails.

The fix:
- Checks if `var.kube_exec_auth_role_arn` is non-empty and uses it if so
- Otherwise, tries `module.iam_roles.terraform_role_arn` (safely returns "" if missing)
- If `kube_exec_auth_role_arn_enabled: false`, the role ARN won't be used, and the evaluation no longer fails

## References
- Context from customer implementations